### PR TITLE
Add dashboard with chat view and guard

### DIFF
--- a/platino-frontend/package-lock.json
+++ b/platino-frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fontsource/roboto": "5.2.5",
         "@mdi/font": "7.4.47",
+        "axios": "^1.10.0",
         "vue": "^3.5.13",
         "vuetify": "^3.8.1"
       },
@@ -2247,6 +2248,23 @@
         "node": ">=16.14.0"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2358,6 +2376,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -2522,6 +2553,18 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comment-parser": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
@@ -2652,6 +2695,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.171",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.171.tgz",
@@ -2677,6 +2743,51 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -3643,6 +3754,42 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3655,6 +3802,52 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -3696,6 +3889,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -3711,6 +3916,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -4141,6 +4385,15 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/memorystream": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -4185,6 +4438,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/min-indent": {
@@ -4741,6 +5015,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/platino-frontend/package.json
+++ b/platino-frontend/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@fontsource/roboto": "5.2.5",
     "@mdi/font": "7.4.47",
+    "axios": "^1.10.0",
     "vue": "^3.5.13",
     "vuetify": "^3.8.1"
   },

--- a/platino-frontend/src/App.vue
+++ b/platino-frontend/src/App.vue
@@ -5,6 +5,5 @@
 </template>
 
 <script lang="ts" setup>
-let num = 0
-num = 'a'  //
+
 </script>

--- a/platino-frontend/src/main.ts
+++ b/platino-frontend/src/main.ts
@@ -15,9 +15,11 @@ import { createApp } from 'vue'
 
 // Styles
 import 'unfonts.css'
-
+import axiosInstance from "./plugins/axios";
 const app = createApp(App)
 
 registerPlugins(app)
+
+app.config.globalProperties.$axios = axiosInstance;
 
 app.mount('#app')

--- a/platino-frontend/src/pages/dashboard/chat.vue
+++ b/platino-frontend/src/pages/dashboard/chat.vue
@@ -1,0 +1,54 @@
+<template>
+  <v-container>
+    <h2 class="mb-4">Chat con IA</h2>
+    <v-list class="mb-4">
+      <v-list-item
+        v-for="(msg, index) in messages"
+        :key="index"
+      >
+        <v-list-item-content>
+          <v-list-item-title class="text-subtitle-1">
+            {{ msg.from }}:
+          </v-list-item-title>
+          <v-list-item-subtitle>{{ msg.text }}</v-list-item-subtitle>
+        </v-list-item-content>
+      </v-list-item>
+    </v-list>
+    <v-text-field
+      v-model="input"
+      label="Escribe tu mensaje"
+      append-icon="mdi-send"
+      @click:append="send"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+interface Message {
+  from: string
+  text: string
+}
+
+const messages = ref<Message[]>([
+  { from: 'AI', text: 'Hola, ¿en qué puedo ayudarte?' },
+])
+
+const input = ref('')
+
+function send () {
+  if (!input.value) return
+  messages.value.push({ from: 'Tú', text: input.value })
+  messages.value.push({
+    from: 'AI',
+    text: 'Esta es una respuesta generada de forma simulada.',
+  })
+  input.value = ''
+}
+</script>
+
+<route lang="yaml">
+meta:
+  requiresAuth: true
+</route>

--- a/platino-frontend/src/pages/dashboard/chat.vue
+++ b/platino-frontend/src/pages/dashboard/chat.vue
@@ -24,26 +24,20 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
+import { useOllamaStore } from '@/stores/ollama'
 
-interface Message {
-  from: string
-  text: string
-}
-
-const messages = ref<Message[]>([
-  { from: 'AI', text: 'Hola, ¿en qué puedo ayudarte?' },
-])
-
+const store = useOllamaStore()
 const input = ref('')
+const messages = computed(() => store.messages)
+
+onMounted(() => {
+  store.connect()
+})
 
 function send () {
   if (!input.value) return
-  messages.value.push({ from: 'Tú', text: input.value })
-  messages.value.push({
-    from: 'AI',
-    text: 'Esta es una respuesta generada de forma simulada.',
-  })
+  store.sendMessage(input.value)
   input.value = ''
 }
 </script>

--- a/platino-frontend/src/pages/dashboard/chat.vue
+++ b/platino-frontend/src/pages/dashboard/chat.vue
@@ -2,10 +2,7 @@
   <v-container>
     <h2 class="mb-4">Chat con IA</h2>
     <v-list class="mb-4">
-      <v-list-item
-        v-for="(msg, index) in messages"
-        :key="index"
-      >
+      <v-list-item v-for="(msg, index) in messages" :key="index">
         <v-list-item-content>
           <v-list-item-title class="text-subtitle-1">
             {{ msg.from }}:
@@ -19,30 +16,55 @@
       label="Escribe tu mensaje"
       append-icon="mdi-send"
       @click:append="send"
+      @keyup.enter="send"
     />
   </v-container>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
-import { useOllamaStore } from '@/stores/ollama'
+import { computed, onMounted, ref } from "vue";
+import { useOllamaStore } from "@/stores/ollama";
+import axios from "axios";
+const store = useOllamaStore();
+const input = ref("");
+const messages = computed(() => store.messages);
 
-const store = useOllamaStore()
-const input = ref('')
-const messages = computed(() => store.messages)
+onMounted(async () => {
+  // store.connect();
+});
 
-onMounted(() => {
-  store.connect()
-})
-
-function send () {
-  if (!input.value) return
-  store.sendMessage(input.value)
-  input.value = ''
+const sendMesageToOllama = async (message: string) => {
+  try {
+    const response = await axios.post("http://localhost:11434/api/generate", {
+      model: "llama3",
+      prompt: message,
+      stream: false,
+    });
+    return response.data;
+  } catch (error) {
+    console.error("Error al enviar el mensaje a Ollama:", error);
+    return null;
+  }
+};
+function send() {
+  if (!input.value) return;
+  store.addMessage({
+    from: "user",
+    text: input.value,
+  });
+  input.value = ""; // Limpiar el campo de entrada
+  sendMesageToOllama(input.value).then((response) => {
+    if (response) {
+      store.addMessage({
+        from: "ai",
+        text: response.response,
+      });
+    }
+  });
 }
 </script>
 
 <route lang="yaml">
 meta:
-  requiresAuth: true
+  requiresAuth: false
 </route>

--- a/platino-frontend/src/pages/dashboard/index.vue
+++ b/platino-frontend/src/pages/dashboard/index.vue
@@ -1,0 +1,20 @@
+<template>
+  <div>
+    <h1>Dashboard</h1>
+    <nav class="mb-4">
+      <RouterLink to="/dashboard/chat">Chat</RouterLink>
+      |
+      <RouterLink to="/dashboard/stats">Stats</RouterLink>
+    </nav>
+    <router-view />
+  </div>
+</template>
+
+<script setup lang="ts">
+//
+</script>
+
+<route lang="yaml">
+meta:
+  requiresAuth: true
+</route>

--- a/platino-frontend/src/pages/dashboard/stats.vue
+++ b/platino-frontend/src/pages/dashboard/stats.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <h2>Stats</h2>
+    <p>Contenido de ejemplo para otra vista anidada.</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+//
+</script>
+
+<route lang="yaml">
+meta:
+  requiresAuth: true
+</route>

--- a/platino-frontend/src/pages/index.vue
+++ b/platino-frontend/src/pages/index.vue
@@ -1,5 +1,4 @@
 <template>
-  <HelloWorld />
   <v-btn class="mt-4" @click="login">Iniciar sesión</v-btn>
   <div class="mt-2">
     <RouterLink to="/dashboard">Ir al Dashboard</RouterLink>
@@ -7,7 +6,7 @@
 </template>
 
 <script setup lang="ts">
-function login () {
-  localStorage.setItem('auth', 'true')
+function login() {
+  localStorage.setItem("auth", "true");
 }
 </script>

--- a/platino-frontend/src/pages/index.vue
+++ b/platino-frontend/src/pages/index.vue
@@ -1,8 +1,13 @@
 <template>
   <HelloWorld />
-  <Hol></Hol>
+  <v-btn class="mt-4" @click="login">Iniciar sesión</v-btn>
+  <div class="mt-2">
+    <RouterLink to="/dashboard">Ir al Dashboard</RouterLink>
+  </div>
 </template>
 
-<script lang="ts" setup>
-//
+<script setup lang="ts">
+function login () {
+  localStorage.setItem('auth', 'true')
+}
 </script>

--- a/platino-frontend/src/plugins/axios.ts
+++ b/platino-frontend/src/plugins/axios.ts
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+const axiosInstance = axios.create({
+  baseURL: "https://mi.api.com/",
+  // Aquí puedes añadir más configuraciones como headers por defecto
+});
+
+export default axiosInstance;

--- a/platino-frontend/src/router/index.ts
+++ b/platino-frontend/src/router/index.ts
@@ -14,6 +14,13 @@ const router = createRouter({
   routes: setupLayouts(routes),
 })
 
+// Simple auth guard example
+router.beforeEach((to) => {
+  if (to.meta.requiresAuth && !localStorage.getItem('auth')) {
+    return { path: '/' }
+  }
+})
+
 // Workaround for https://github.com/vitejs/vite/issues/11804
 router.onError((err, to) => {
   if (err?.message?.includes?.('Failed to fetch dynamically imported module')) {

--- a/platino-frontend/src/stores/ollama.ts
+++ b/platino-frontend/src/stores/ollama.ts
@@ -1,0 +1,46 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export interface ChatMessage {
+  from: 'user' | 'ai'
+  text: string
+}
+
+export const useOllamaStore = defineStore('ollama', () => {
+  const messages = ref<ChatMessage[]>([])
+  const connected = ref(false)
+  let socket: WebSocket | null = null
+
+  function connect () {
+    if (socket || connected.value) return
+
+    socket = new WebSocket('ws://localhost:11434/api/chat')
+
+    socket.addEventListener('open', () => {
+      connected.value = true
+    })
+
+    socket.addEventListener('message', (e) => {
+      messages.value.push({ from: 'ai', text: e.data })
+    })
+
+    socket.addEventListener('close', () => {
+      connected.value = false
+      socket = null
+    })
+  }
+
+  function disconnect () {
+    if (socket) {
+      socket.close()
+    }
+  }
+
+  function sendMessage (text: string) {
+    if (!socket || socket.readyState !== WebSocket.OPEN) connect()
+    socket?.send(text)
+    messages.value.push({ from: 'user', text })
+  }
+
+  return { messages, connected, connect, disconnect, sendMessage }
+})

--- a/platino-frontend/src/stores/ollama.ts
+++ b/platino-frontend/src/stores/ollama.ts
@@ -1,46 +1,48 @@
-import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { defineStore } from "pinia";
+import { ref } from "vue";
 
 export interface ChatMessage {
-  from: 'user' | 'ai'
-  text: string
+  from: "user" | "ai";
+  text: string;
 }
 
-export const useOllamaStore = defineStore('ollama', () => {
-  const messages = ref<ChatMessage[]>([])
-  const connected = ref(false)
-  let socket: WebSocket | null = null
+export const useOllamaStore = defineStore("ollama", () => {
+  const messages = ref<ChatMessage[]>([]);
+  const connected = ref(false);
+  let socket: WebSocket | null = null;
 
-  function connect () {
-    if (socket || connected.value) return
+  function connect() {
+    if (socket || connected.value) return;
 
-    socket = new WebSocket('ws://localhost:11434/api/chat')
+    socket = new WebSocket("ws://localhost:11434/api/chat");
 
-    socket.addEventListener('open', () => {
-      connected.value = true
-    })
+    socket.addEventListener("open", () => {
+      connected.value = true;
+    });
 
-    socket.addEventListener('message', (e) => {
-      messages.value.push({ from: 'ai', text: e.data })
-    })
+    socket.addEventListener("message", (e) => {
+      messages.value.push({ from: "ai", text: e.data });
+    });
 
-    socket.addEventListener('close', () => {
-      connected.value = false
-      socket = null
-    })
+    socket.addEventListener("close", () => {
+      connected.value = false;
+      socket = null;
+    });
   }
 
-  function disconnect () {
+  function disconnect() {
     if (socket) {
-      socket.close()
+      socket.close();
     }
   }
 
-  function sendMessage (text: string) {
-    if (!socket || socket.readyState !== WebSocket.OPEN) connect()
-    socket?.send(text)
-    messages.value.push({ from: 'user', text })
+  function sendMessage(text: string) {
+    if (!socket || socket.readyState !== WebSocket.OPEN) connect();
+    socket?.send(text);
+    messages.value.push({ from: "user", text });
   }
-
-  return { messages, connected, connect, disconnect, sendMessage }
-})
+  function addMessage(message: ChatMessage) {
+    messages.value.push(message);
+  }
+  return { messages, connected, connect, disconnect, sendMessage, addMessage };
+});

--- a/platino-frontend/src/typed-router.d.ts
+++ b/platino-frontend/src/typed-router.d.ts
@@ -19,5 +19,8 @@ declare module 'vue-router/auto-routes' {
    */
   export interface RouteNamedMap {
     '/': RouteRecordInfo<'/', '/', Record<never, never>, Record<never, never>>,
+    '/dashboard/': RouteRecordInfo<'/dashboard/', '/dashboard', Record<never, never>, Record<never, never>>,
+    '/dashboard/chat': RouteRecordInfo<'/dashboard/chat', '/dashboard/chat', Record<never, never>, Record<never, never>>,
+    '/dashboard/stats': RouteRecordInfo<'/dashboard/stats', '/dashboard/stats', Record<never, never>, Record<never, never>>,
   }
 }


### PR DESCRIPTION
## Summary
- create nested `dashboard` section
- add `chat` view with a simple hardcoded AI conversation
- show an additional `stats` view
- demonstrate login and navigation via a button on the home page
- implement a simple global auth navigation guard

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn type-check` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68546d1b91d8832490b69982e848068a