### PR TITLE
Add PDF drop support to chat page

### DIFF
--- a/platino-backend/README.md
+++ b/platino-backend/README.md
@@ -18,5 +18,6 @@ uvicorn app.main:app --reload
 ```
 
 El websocket está disponible en `/ws/chat` y los endpoints para manejo de archivos en `/api/files`.
+El endpoint `/api/split_pdf` permite enviar un PDF y recibir los textos divididos en chunks utilizando LlamaIndex.
 
 Puedes consultar la documentación automática (Swagger UI) en `http://localhost:8000/docs` cuando la aplicación esté en marcha.

--- a/platino-backend/app/api/endpoints/rag.py
+++ b/platino-backend/app/api/endpoints/rag.py
@@ -1,6 +1,10 @@
 from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
 from sqlalchemy.orm import Session
 from typing import List
+from io import BytesIO
+
+from llama_index.readers.file import PDFReader
+from llama_index.core.node_parser import SimpleNodeParser
 
 from ...db.session import get_db
 from ...db.models import Document
@@ -33,3 +37,18 @@ async def list_files(db: Session = Depends(get_db)):
     docs = db.query(Document).all()
     filenames = [doc.filename for doc in docs]
     return {"files": filenames}
+
+
+@router.post("/split_pdf")
+async def split_pdf(file: UploadFile = File(...)):
+    """Return PDF chunks using LlamaIndex."""
+    try:
+        contents = await file.read()
+        pdf_reader = PDFReader()
+        documents = pdf_reader.load_data(BytesIO(contents))
+        parser = SimpleNodeParser.from_defaults()
+        nodes = parser.get_nodes_from_documents(documents)
+        chunks = [node.text for node in nodes]
+        return {"chunks": chunks}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/platino-backend/app/api/endpoints/rag.py
+++ b/platino-backend/app/api/endpoints/rag.py
@@ -2,9 +2,11 @@ from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
 from sqlalchemy.orm import Session
 from typing import List
 from io import BytesIO
-
+from llama_index.readers.file import PyMuPDFReader
+from fastapi.middleware.cors import CORSMiddleware
 from llama_index.readers.file import PDFReader
 from llama_index.core.node_parser import SimpleNodeParser
+import tempfile
 
 from ...db.session import get_db
 from ...db.models import Document
@@ -52,3 +54,31 @@ async def split_pdf(file: UploadFile = File(...)):
         return {"chunks": chunks}
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/files_2")
+async def upload_and_split_pdf(file: UploadFile = File(...)):
+    if not file.filename.endswith(".pdf"):
+        raise HTTPException(status_code=400, detail="Solo se permiten archivos PDF")
+
+    try:
+        content = await file.read()
+
+        # Escribir contenido a archivo temporal
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+            tmp.write(content)
+            tmp_path = tmp.name
+
+        # Leer el PDF usando la ruta temporal
+        reader = PyMuPDFReader()
+        documents = reader.load_data(file_path=tmp_path)
+
+        # Dividir en chunks
+        parser = SimpleNodeParser()
+        nodes = parser.get_nodes_from_documents(documents)
+        chunks = [node.text for node in nodes]
+
+        return {"filename": file.filename, "chunks": chunks}
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/platino-backend/requirements.txt
+++ b/platino-backend/requirements.txt
@@ -5,3 +5,4 @@ sqlalchemy
 pydantic>=2.7.0
 pydantic-settings>=2.1.0
 python-dotenv>=1.1.1
+llama-index>=0.10.0

--- a/platino-frontend/src/pages/dashboard/chat.vue
+++ b/platino-frontend/src/pages/dashboard/chat.vue
@@ -61,11 +61,8 @@ async function uploadPdf(file: File) {
   formData.append("file", file);
   try {
     const { data } = await axios.post(
-      "http://localhost:8000/api/split_pdf",
-      formData,
-      {
-        headers: { "Content-Type": "multipart/form-data" },
-      }
+      "http://localhost:8000/api/files_2",
+      formData
     );
     if (data.chunks) {
       data.chunks.forEach((chunk: string) => {

--- a/platino-frontend/src/pages/dashboard/chat.vue
+++ b/platino-frontend/src/pages/dashboard/chat.vue
@@ -11,12 +11,21 @@
         </v-list-item-content>
       </v-list-item>
     </v-list>
+    <input
+      ref="fileInput"
+      type="file"
+      accept="application/pdf"
+      class="d-none"
+      @change="handleFileChange"
+    />
     <v-text-field
       v-model="input"
       label="Escribe tu mensaje"
       append-icon="mdi-send"
       @click:append="send"
       @keyup.enter="send"
+      @dragover.prevent
+      @drop.prevent="onDrop"
     />
   </v-container>
 </template>
@@ -29,6 +38,44 @@ import axios from "axios";
 const store = useOllamaStore();
 const input = ref("");
 const messages = computed(() => store.messages);
+const fileInput = ref<HTMLInputElement | null>(null);
+
+function onDrop(e: DragEvent) {
+  const files = e.dataTransfer?.files;
+  if (files && files.length > 0) {
+    uploadPdf(files[0]);
+  }
+}
+
+function handleFileChange(e: Event) {
+  const target = e.target as HTMLInputElement;
+  const files = target.files;
+  if (files && files.length > 0) {
+    uploadPdf(files[0]);
+  }
+  if (target) target.value = "";
+}
+
+async function uploadPdf(file: File) {
+  const formData = new FormData();
+  formData.append("file", file);
+  try {
+    const { data } = await axios.post(
+      "http://localhost:8000/api/split_pdf",
+      formData,
+      {
+        headers: { "Content-Type": "multipart/form-data" },
+      }
+    );
+    if (data.chunks) {
+      data.chunks.forEach((chunk: string) => {
+        store.addMessage({ from: "ai", text: chunk });
+      });
+    }
+  } catch (err) {
+    console.error("Error al dividir PDF:", err);
+  }
+}
 
 onMounted(async () => {
   store.connect();


### PR DESCRIPTION
## Summary
- allow dropping PDF files onto chat input
- post dropped PDF to `/api/split_pdf`
- display resulting chunks as chat messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d774eeb048324ad9991071e5359ad