### PR TITLE
Add document management features

### DIFF
--- a/platino-backend/app/api/endpoints/rag.py
+++ b/platino-backend/app/api/endpoints/rag.py
@@ -54,7 +54,7 @@ async def upload_file(
             filename=file.filename,
             filepath=str(path),
             thumbnail=thumb_path,
-            metadata=metadata,
+            file_metadata=metadata,
             chunks=chunks,
         )
         db.add(doc_db)
@@ -126,10 +126,10 @@ async def rename_file(doc_id: int, new_name: str, db: Session = Depends(get_db))
         doc.thumbnail = str(new_thumb)
 
     doc.filename = new_name
-    meta = doc.metadata or {}
+    meta = doc.file_metadata or {}
     meta["filename"] = new_name
     meta["source"] = str(new_path)
-    doc.metadata = meta
+    doc.file_metadata = meta
 
     db.commit()
     db.refresh(doc)

--- a/platino-backend/app/api/endpoints/rag.py
+++ b/platino-backend/app/api/endpoints/rag.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
+import os
 from sqlalchemy.orm import Session
 from typing import List
 from io import BytesIO
@@ -31,10 +32,12 @@ async def upload_file(
 
         thumb_path = None
         chunks: List[str] = []
+        metadata = {"filename": file.filename, "source": str(path)}
 
         if file.filename.lower().endswith(".pdf"):
             # generate thumbnail
             doc_pdf = fitz.open(path)
+            metadata["pages"] = doc_pdf.page_count
             page = doc_pdf.load_page(0)
             pix = page.get_pixmap()
             thumb_path = str(UPLOAD_DIR / f"{file.filename}.png")
@@ -51,6 +54,8 @@ async def upload_file(
             filename=file.filename,
             filepath=str(path),
             thumbnail=thumb_path,
+            metadata=metadata,
+            chunks=chunks,
         )
         db.add(doc_db)
         db.commit()
@@ -61,6 +66,7 @@ async def upload_file(
             "filename": doc_db.filename,
             "thumbnail": doc_db.thumbnail,
             "chunks": chunks,
+            "metadata": metadata,
         }
 
     except Exception as e:
@@ -81,6 +87,57 @@ async def list_files(db: Session = Depends(get_db)):
         for doc in docs
     ]
     return {"files": files}
+
+
+@router.delete("/files/{doc_id}")
+async def delete_file(doc_id: int, db: Session = Depends(get_db)):
+    """Delete a document and its files."""
+    doc = db.query(Document).get(doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    if os.path.exists(doc.filepath):
+        os.remove(doc.filepath)
+    if doc.thumbnail and os.path.exists(doc.thumbnail):
+        os.remove(doc.thumbnail)
+
+    db.delete(doc)
+    db.commit()
+    return {"status": "deleted"}
+
+
+@router.put("/files/{doc_id}")
+async def rename_file(doc_id: int, new_name: str, db: Session = Depends(get_db)):
+    """Rename a stored document."""
+    doc = db.query(Document).get(doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    new_path = UPLOAD_DIR / new_name
+    if new_path.exists():
+        raise HTTPException(status_code=400, detail="Filename already exists")
+
+    os.rename(doc.filepath, new_path)
+    doc.filepath = str(new_path)
+    if doc.thumbnail:
+        thumb_ext = Path(doc.thumbnail).suffix
+        new_thumb = UPLOAD_DIR / f"{new_name}{thumb_ext}"
+        os.rename(doc.thumbnail, new_thumb)
+        doc.thumbnail = str(new_thumb)
+
+    doc.filename = new_name
+    meta = doc.metadata or {}
+    meta["filename"] = new_name
+    meta["source"] = str(new_path)
+    doc.metadata = meta
+
+    db.commit()
+    db.refresh(doc)
+    return {
+        "id": doc.id,
+        "filename": doc.filename,
+        "thumbnail": doc.thumbnail,
+    }
 
 
 @router.post("/split_pdf")

--- a/platino-backend/app/db/models.py
+++ b/platino-backend/app/db/models.py
@@ -21,7 +21,9 @@ class Document(Base):
     filename = Column(String, unique=True, index=True, nullable=False)
     filepath = Column(String, nullable=False)
     thumbnail = Column(String, nullable=True)
-    metadata = Column(JSON, nullable=True)
+    # "metadata" is reserved by SQLAlchemy's declarative system, so use a
+    # different attribute name while keeping the same column name in the DB.
+    file_metadata = Column("metadata", JSON, nullable=True)
     chunks = Column(JSON, nullable=True)
     owner_id = Column(Integer, ForeignKey("users.id"))
 

--- a/platino-backend/app/db/models.py
+++ b/platino-backend/app/db/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, Integer, String, ForeignKey, JSON
 from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
@@ -21,6 +21,8 @@ class Document(Base):
     filename = Column(String, unique=True, index=True, nullable=False)
     filepath = Column(String, nullable=False)
     thumbnail = Column(String, nullable=True)
+    metadata = Column(JSON, nullable=True)
+    chunks = Column(JSON, nullable=True)
     owner_id = Column(Integer, ForeignKey("users.id"))
 
     owner = relationship("User", back_populates="documents")

--- a/platino-frontend/src/pages/dashboard/files.vue
+++ b/platino-frontend/src/pages/dashboard/files.vue
@@ -23,9 +23,11 @@
             >
               <v-card>
                 <v-img :src="doc.thumbnail" height="120" cover />
-                <v-card-title class="text-wrap">{{
-                  doc.filename
-                }}</v-card-title>
+                <v-card-title class="text-wrap">{{ doc.filename }}</v-card-title>
+                <v-card-actions>
+                  <v-btn icon="mdi-pencil" @click="rename(doc)" size="small" />
+                  <v-btn icon="mdi-delete" @click="remove(doc.id)" size="small" />
+                </v-card-actions>
               </v-card>
             </v-col>
           </v-row>
@@ -60,6 +62,24 @@ function upload(file: File) {
   axios.post("http://localhost:8000/api/files", formData).then((res) => {
     documents.value.push(res.data);
   });
+}
+
+function remove(id: number) {
+  axios.delete(`http://localhost:8000/api/files/${id}`).then(() => {
+    documents.value = documents.value.filter((d) => d.id !== id);
+  });
+}
+
+function rename(doc: Doc) {
+  const newName = prompt("Nuevo nombre", doc.filename);
+  if (!newName || newName === doc.filename) return;
+  axios
+    .put(`http://localhost:8000/api/files/${doc.id}`, null, {
+      params: { new_name: newName },
+    })
+    .then((res) => {
+      doc.filename = res.data.filename;
+    });
 }
 
 function handleFileUpload(newFile: File | File[]) {


### PR DESCRIPTION
## Summary
- support metadata and chunk storage for uploaded documents
- add endpoints to rename or delete documents
- show rename & delete buttons in the files view

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-vuetify' due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6862ec7bed948324b2d28402f370f807