### PR TITLE
Add modules and topics

### DIFF
--- a/platino-backend/app/api/endpoints/modules.py
+++ b/platino-backend/app/api/endpoints/modules.py
@@ -28,6 +28,16 @@ def update_module(module_id: int, title: str, db: Session = Depends(get_db)):
     db.refresh(module)
     return {"id": module.id, "title": module.title}
 
+
+@router.delete("/modules/{module_id}")
+def delete_module(module_id: int, db: Session = Depends(get_db)):
+    module = db.query(Module).get(module_id)
+    if not module:
+        raise HTTPException(status_code=404, detail="Module not found")
+    db.delete(module)
+    db.commit()
+    return {"status": "deleted"}
+
 @router.post("/modules/{module_id}/topics")
 def create_topic(module_id: int, title: str, db: Session = Depends(get_db)):
     module = db.query(Module).get(module_id)
@@ -57,3 +67,13 @@ def update_topic(topic_id: int, title: str, db: Session = Depends(get_db)):
     db.commit()
     db.refresh(topic)
     return {"id": topic.id, "title": topic.title, "module_id": topic.module_id}
+
+
+@router.delete("/topics/{topic_id}")
+def delete_topic(topic_id: int, db: Session = Depends(get_db)):
+    topic = db.query(Topic).get(topic_id)
+    if not topic:
+        raise HTTPException(status_code=404, detail="Topic not found")
+    db.delete(topic)
+    db.commit()
+    return {"status": "deleted"}

--- a/platino-backend/app/api/endpoints/modules.py
+++ b/platino-backend/app/api/endpoints/modules.py
@@ -1,0 +1,59 @@
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.orm import Session
+from ...db.session import get_db
+from ...db.models import Module, Topic
+
+router = APIRouter()
+
+@router.post("/modules")
+def create_module(title: str, db: Session = Depends(get_db)):
+    module = Module(title=title)
+    db.add(module)
+    db.commit()
+    db.refresh(module)
+    return {"id": module.id, "title": module.title}
+
+@router.get("/modules")
+def list_modules(db: Session = Depends(get_db)):
+    modules = db.query(Module).all()
+    return {"modules": [{"id": m.id, "title": m.title} for m in modules]}
+
+@router.put("/modules/{module_id}")
+def update_module(module_id: int, title: str, db: Session = Depends(get_db)):
+    module = db.query(Module).get(module_id)
+    if not module:
+        raise HTTPException(status_code=404, detail="Module not found")
+    module.title = title
+    db.commit()
+    db.refresh(module)
+    return {"id": module.id, "title": module.title}
+
+@router.post("/modules/{module_id}/topics")
+def create_topic(module_id: int, title: str, db: Session = Depends(get_db)):
+    module = db.query(Module).get(module_id)
+    if not module:
+        raise HTTPException(status_code=404, detail="Module not found")
+    topic = Topic(title=title, module_id=module_id)
+    db.add(topic)
+    db.commit()
+    db.refresh(topic)
+    return {"id": topic.id, "title": topic.title, "module_id": module_id}
+
+@router.get("/modules/{module_id}/topics")
+def list_topics(module_id: int, db: Session = Depends(get_db)):
+    topics = db.query(Topic).filter_by(module_id=module_id).all()
+    return {
+        "topics": [
+            {"id": t.id, "title": t.title, "module_id": t.module_id} for t in topics
+        ]
+    }
+
+@router.put("/topics/{topic_id}")
+def update_topic(topic_id: int, title: str, db: Session = Depends(get_db)):
+    topic = db.query(Topic).get(topic_id)
+    if not topic:
+        raise HTTPException(status_code=404, detail="Topic not found")
+    topic.title = title
+    db.commit()
+    db.refresh(topic)
+    return {"id": topic.id, "title": topic.title, "module_id": topic.module_id}

--- a/platino-backend/app/api/endpoints/rag.py
+++ b/platino-backend/app/api/endpoints/rag.py
@@ -10,7 +10,7 @@ from llama_index.core.node_parser import SimpleNodeParser
 import tempfile
 import traceback
 from ...db.session import get_db
-from ...db.models import Document
+from ...db.models import Document, Topic
 
 router = APIRouter()
 
@@ -21,6 +21,7 @@ UPLOAD_DIR.mkdir(exist_ok=True)
 async def upload_file(
     file: UploadFile = File(...),
     db: Session = Depends(get_db),
+    topic_id: int | None = None,
 ):
     """Upload a file, store it and generate chunks."""
     try:
@@ -50,12 +51,18 @@ async def upload_file(
             nodes = parser.get_nodes_from_documents(documents)
             chunks = [node.text for node in nodes]
 
+        if topic_id is not None:
+            topic = db.query(Topic).get(topic_id)
+            if not topic:
+                raise HTTPException(status_code=404, detail="Topic not found")
+
         doc_db = Document(
             filename=file.filename,
             filepath=str(path),
             thumbnail=thumb_path,
             file_metadata=metadata,
             chunks=chunks,
+            topic_id=topic_id,
         )
         db.add(doc_db)
         db.commit()
@@ -67,6 +74,7 @@ async def upload_file(
             "thumbnail": doc_db.thumbnail,
             "chunks": chunks,
             "metadata": metadata,
+            "topic_id": doc_db.topic_id,
         }
 
     except Exception as e:
@@ -83,6 +91,7 @@ async def list_files(db: Session = Depends(get_db)):
             "id": doc.id,
             "filename": doc.filename,
             "thumbnail": doc.thumbnail,
+            "topic_id": doc.topic_id,
         }
         for doc in docs
     ]
@@ -137,7 +146,25 @@ async def rename_file(doc_id: int, new_name: str, db: Session = Depends(get_db))
         "id": doc.id,
         "filename": doc.filename,
         "thumbnail": doc.thumbnail,
+        "topic_id": doc.topic_id,
     }
+
+
+@router.put("/files/{doc_id}/topic")
+async def set_file_topic(doc_id: int, topic_id: int | None, db: Session = Depends(get_db)):
+    doc = db.query(Document).get(doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    if topic_id is not None:
+        topic = db.query(Topic).get(topic_id)
+        if not topic:
+            raise HTTPException(status_code=404, detail="Topic not found")
+
+    doc.topic_id = topic_id
+    db.commit()
+    db.refresh(doc)
+    return {"id": doc.id, "topic_id": doc.topic_id}
 
 
 @router.post("/split_pdf")

--- a/platino-backend/app/db/models.py
+++ b/platino-backend/app/db/models.py
@@ -4,6 +4,26 @@ from sqlalchemy.orm import declarative_base, relationship
 Base = declarative_base()
 
 
+class Module(Base):
+    __tablename__ = "modules"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, nullable=False)
+
+    topics = relationship("Topic", back_populates="module", cascade="all, delete")
+
+
+class Topic(Base):
+    __tablename__ = "topics"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, nullable=False)
+    module_id = Column(Integer, ForeignKey("modules.id"), nullable=False)
+
+    module = relationship("Module", back_populates="topics")
+    documents = relationship("Document", back_populates="topic", cascade="all, delete")
+
+
 class User(Base):
     __tablename__ = "users"
 
@@ -26,5 +46,7 @@ class Document(Base):
     file_metadata = Column("metadata", JSON, nullable=True)
     chunks = Column(JSON, nullable=True)
     owner_id = Column(Integer, ForeignKey("users.id"))
+    topic_id = Column(Integer, ForeignKey("topics.id"), nullable=True)
 
     owner = relationship("User", back_populates="documents")
+    topic = relationship("Topic", back_populates="documents")

--- a/platino-backend/app/main.py
+++ b/platino-backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from .api.endpoints import rag
+from .api.endpoints import rag, modules
 from .websocket import llm
 from .db.session import engine
 from .db.models import Base
@@ -25,6 +25,7 @@ app.add_middleware(
 )
 
 app.include_router(rag.router, prefix="/api")
+app.include_router(modules.router, prefix="/api")
 app.include_router(llm.router)
 
 @app.get("/")

--- a/platino-frontend/src/pages/dashboard/files.vue
+++ b/platino-frontend/src/pages/dashboard/files.vue
@@ -65,14 +65,20 @@
           <div class="text-subtitle-2 mt-4 mb-2" @click="editModule(mod)">
             {{ mod.title }}
           </div>
-          <v-btn icon="mdi-plus" class="ml-auto" size="small" @click="addTopic(mod)" />
+          <div class="d-flex align-center ml-auto">
+            <v-btn icon="mdi-plus" size="small" @click="addTopic(mod)" />
+            <v-btn icon="mdi-delete" size="small" class="ml-2" @click="removeModule(mod)" />
+          </div>
         </div>
         <v-expansion-panels class="my-4" variant="inset">
           <v-expansion-panel v-for="topic in mod.topics" :key="topic.id">
             <template #title>
               <div class="d-flex align-center justify-between w-100">
                 <span>{{ topic.title }}</span>
-                <v-btn icon="mdi-pencil" size="small" @click.stop="editTopic(topic)" />
+                <div>
+                  <v-btn icon="mdi-pencil" size="small" @click.stop="editTopic(topic)" />
+                  <v-btn icon="mdi-delete" size="small" class="ml-2" @click.stop="removeTopic(mod, topic)" />
+                </div>
               </div>
             </template>
             <template #text>
@@ -199,6 +205,23 @@ function editTopic(topic: Topic) {
     .then((res) => {
       topic.title = res.data.title;
     });
+}
+
+function removeModule(module: Module) {
+  if (!confirm("¿Eliminar módulo y sus temarios?")) return;
+  axios.delete(`http://localhost:8000/api/modules/${module.id}`).then(() => {
+    modules.value = modules.value.filter((m) => m.id !== module.id);
+    const topicIds = module.topics.map((t) => t.id);
+    documents.value = documents.value.filter((d) => !topicIds.includes(d.topic_id ?? -1));
+  });
+}
+
+function removeTopic(module: Module, topic: Topic) {
+  if (!confirm("¿Eliminar temario?")) return;
+  axios.delete(`http://localhost:8000/api/topics/${topic.id}`).then(() => {
+    module.topics = module.topics.filter((t) => t.id !== topic.id);
+    documents.value = documents.value.filter((d) => d.topic_id !== topic.id);
+  });
 }
 
 function rename(doc: Doc) {

--- a/platino-frontend/src/pages/dashboard/files.vue
+++ b/platino-frontend/src/pages/dashboard/files.vue
@@ -47,17 +47,51 @@
     </v-row>
     <v-row>
       <v-col cols="12">
+        <v-select
+          label="Asignar a temario"
+          :items="topicsList"
+          item-title="title"
+          item-value="id"
+          v-model="selectedTopicId"
+          clearable
+          class="mb-4"
+        />
+        <v-btn icon="mdi-plus" class="ml-2" size="small" @click="addModule" />
+      </v-col>
+    </v-row>
+    <v-row v-for="mod in modules" :key="mod.id">
+      <v-col cols="12">
         <div class="d-flex justify-between align-items-center">
-          <div class="text-subtitle-2 mt-4 mb-2">Modulo 1</div>
-          <v-btn icon="mdi-plus" class="ml-auto" size="small"></v-btn>
+          <div class="text-subtitle-2 mt-4 mb-2" @click="editModule(mod)">
+            {{ mod.title }}
+          </div>
+          <v-btn icon="mdi-plus" class="ml-auto" size="small" @click="addTopic(mod)" />
         </div>
         <v-expansion-panels class="my-4" variant="inset">
-          <v-expansion-panel
-            v-for="i in 3"
-            :key="i"
-            text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
-            :title="'Tema' + ' ' + i"
-          ></v-expansion-panel>
+          <v-expansion-panel v-for="topic in mod.topics" :key="topic.id">
+            <template #title>
+              <div class="d-flex align-center justify-between w-100">
+                <span>{{ topic.title }}</span>
+                <v-btn icon="mdi-pencil" size="small" @click.stop="editTopic(topic)" />
+              </div>
+            </template>
+            <template #text>
+              <v-row>
+                <v-col
+                  cols="12"
+                  sm="6"
+                  md="3"
+                  v-for="doc in documents.filter((d) => d.topic_id === topic.id)"
+                  :key="doc.id"
+                >
+                  <v-card>
+                    <v-img :src="`http://localhost:8000/${doc.thumbnail}`" height="120" cover />
+                    <v-card-title class="text-wrap">{{ doc.filename }}</v-card-title>
+                  </v-card>
+                </v-col>
+              </v-row>
+            </template>
+          </v-expansion-panel>
         </v-expansion-panels>
       </v-col>
     </v-row>
@@ -65,16 +99,25 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
+import { ref, onMounted, computed } from "vue";
 import axios from "axios";
 
 interface Doc {
   id: number;
   filename: string;
   thumbnail: string | null;
+  topic_id: number | null;
 }
 
 const documents = ref<Doc[]>([]);
+interface Topic { id: number; title: string; module_id: number }
+interface Module { id: number; title: string; topics: Topic[] }
+
+const modules = ref<Module[]>([]);
+const selectedTopicId = ref<number | null>(null);
+const topicsList = computed(() =>
+  modules.value.flatMap((m) => m.topics)
+);
 
 function loadFiles() {
   axios.get("http://localhost:8000/api/files").then((res) => {
@@ -82,18 +125,80 @@ function loadFiles() {
   });
 }
 
+function loadModules() {
+  axios.get("http://localhost:8000/api/modules").then((res) => {
+    modules.value = res.data.modules.map((m: any) => ({ ...m, topics: [] }));
+    modules.value.forEach((m) => {
+      axios
+        .get(`http://localhost:8000/api/modules/${m.id}/topics`)
+        .then((r) => {
+          const mod = modules.value.find((mm) => mm.id === m.id);
+          if (mod) mod.topics = r.data.topics;
+        });
+    });
+  });
+}
+
 function upload(file: File) {
   const formData = new FormData();
   formData.append("file", file);
-  axios.post("http://localhost:8000/api/files", formData).then((res) => {
-    documents.value.push(res.data);
-  });
+  axios
+    .post("http://localhost:8000/api/files", formData, {
+      params: { topic_id: selectedTopicId.value },
+    })
+    .then((res) => {
+      documents.value.push(res.data);
+    });
 }
 
 function remove(id: number) {
   axios.delete(`http://localhost:8000/api/files/${id}`).then(() => {
     documents.value = documents.value.filter((d) => d.id !== id);
   });
+}
+
+function addModule() {
+  const title = prompt("Nombre del módulo");
+  if (!title) return;
+  axios
+    .post("http://localhost:8000/api/modules", null, { params: { title } })
+    .then((res) => {
+      modules.value.push({ ...res.data, topics: [] });
+    });
+}
+
+function addTopic(module: Module) {
+  const title = prompt("Nombre del temario");
+  if (!title) return;
+  axios
+    .post(`http://localhost:8000/api/modules/${module.id}/topics`, null, {
+      params: { title },
+    })
+    .then((res) => {
+      module.topics.push(res.data);
+    });
+}
+
+function editModule(module: Module) {
+  const title = prompt("Nuevo título", module.title);
+  if (!title || title === module.title) return;
+  axios
+    .put(`http://localhost:8000/api/modules/${module.id}`, null, {
+      params: { title },
+    })
+    .then((res) => {
+      module.title = res.data.title;
+    });
+}
+
+function editTopic(topic: Topic) {
+  const title = prompt("Nuevo título", topic.title);
+  if (!title || title === topic.title) return;
+  axios
+    .put(`http://localhost:8000/api/topics/${topic.id}`, null, { params: { title } })
+    .then((res) => {
+      topic.title = res.data.title;
+    });
 }
 
 function rename(doc: Doc) {
@@ -121,5 +226,8 @@ function onDrop(e: DragEvent) {
   }
 }
 
-onMounted(loadFiles);
+onMounted(() => {
+  loadFiles();
+  loadModules();
+});
 </script>


### PR DESCRIPTION
## Summary
- add `Module` and `Topic` DB models
- support module/topic creation API
- allow assigning files to topics
- show modules and topics in the files UI with editable titles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863860901a08324958977ed93fe60ef