### PR TITLE
Add docker compose for full platform

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 8000
+CMD ["npm", "start"]

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,5 @@
+const express = require('express');
+const app = express();
+const port = 8000;
+app.get('/', (req, res) => res.send('Backend running'));
+app.listen(port, () => console.log(`Server listening on port ${port}`));

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "platino-backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "pg": "^8.11.0"
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: platino
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  backend:
+    build: ./backend
+    volumes:
+      - ./backend:/app
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+
+  frontend:
+    build:
+      context: ./platino-frontend
+    volumes:
+      - ./platino-frontend:/app
+      - /app/node_modules
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend
+
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama:/root/.ollama
+    command: bash -c "ollama pull llama3 && ollama serve"
+
+volumes:
+  db_data:
+  ollama:

--- a/platino-frontend/Dockerfile
+++ b/platino-frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host"]


### PR DESCRIPTION
## Summary
- setup backend service with express
- add Dockerfiles for backend and frontend
- orchestrate services with docker-compose
- include ollama with llama3

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-vuetify' due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686c184d0d388324ad8305383471263a