### PR TITLE
Integrate GPT with fallback to local Ollama

### DIFF
--- a/platino-backend/app/api/endpoints/llm.py
+++ b/platino-backend/app/api/endpoints/llm.py
@@ -4,11 +4,16 @@ import os
 import httpx
 import json
 from openai import AsyncOpenAI
+from pydantic import BaseModel
 
 router = APIRouter()
 
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434/api/generate")
+
+
+class PromptRequest(BaseModel):
+    prompt: str
 
 async def stream_openai(prompt: str):
     if not OPENAI_API_KEY:
@@ -37,7 +42,9 @@ async def stream_ollama(prompt: str):
                     yield line + "\n"
 
 @router.post("/chat/stream")
-async def chat_stream(prompt: str):
+async def chat_stream(data: PromptRequest):
+    prompt = data.prompt
+
     async def generator():
         try:
             async for chunk in stream_openai(prompt):

--- a/platino-backend/app/api/endpoints/llm.py
+++ b/platino-backend/app/api/endpoints/llm.py
@@ -1,0 +1,48 @@
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
+import os
+import httpx
+import json
+from openai import AsyncOpenAI
+
+router = APIRouter()
+
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434/api/generate")
+
+async def stream_openai(prompt: str):
+    if not OPENAI_API_KEY:
+        raise ValueError("OPENAI_API_KEY not configured")
+    client = AsyncOpenAI(api_key=OPENAI_API_KEY)
+    stream = await client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+        stream=True,
+    )
+    async for chunk in stream:
+        delta = chunk.choices[0].delta.content
+        if delta:
+            yield json.dumps({"response": delta}) + "\n"
+
+async def stream_ollama(prompt: str):
+    async with httpx.AsyncClient() as client:
+        async with client.stream(
+            "POST",
+            OLLAMA_URL,
+            json={"model": "llama3", "prompt": prompt, "stream": True},
+        ) as resp:
+            resp.raise_for_status()
+            async for line in resp.aiter_lines():
+                if line.strip():
+                    yield line + "\n"
+
+@router.post("/chat/stream")
+async def chat_stream(prompt: str):
+    async def generator():
+        try:
+            async for chunk in stream_openai(prompt):
+                yield chunk
+        except Exception:
+            async for chunk in stream_ollama(prompt):
+                yield chunk
+    return StreamingResponse(generator(), media_type="application/json")

--- a/platino-backend/app/api/endpoints/llm.py
+++ b/platino-backend/app/api/endpoints/llm.py
@@ -5,32 +5,39 @@ import httpx
 import json
 from openai import AsyncOpenAI
 from pydantic import BaseModel
-
+from app.core.config import settings  
 router = APIRouter()
 
-OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+OPENAI_API_KEY = settings.openai_api_key
 OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434/api/generate")
 
+client = AsyncOpenAI(api_key=settings.openai_api_key)
 
+# 👇 Ahora el usuario puede enviar también el proveedor
 class PromptRequest(BaseModel):
     prompt: str
+    provider: str  # "openai" o "ollama"
 
 async def stream_openai(prompt: str):
     if not OPENAI_API_KEY:
         raise ValueError("OPENAI_API_KEY not configured")
-    client = AsyncOpenAI(api_key=OPENAI_API_KEY)
+    print('OpenAI connected')
+
     stream = await client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": prompt}],
         stream=True,
     )
+
     async for chunk in stream:
         delta = chunk.choices[0].delta.content
         if delta:
             yield json.dumps({"response": delta}) + "\n"
 
 async def stream_ollama(prompt: str):
-    async with httpx.AsyncClient() as client:
+    print('Ollama connected')
+    timeout = httpx.Timeout(60.0, connect=10.0)
+    async with httpx.AsyncClient(timeout=timeout) as client:
         async with client.stream(
             "POST",
             OLLAMA_URL,
@@ -44,12 +51,14 @@ async def stream_ollama(prompt: str):
 @router.post("/chat/stream")
 async def chat_stream(data: PromptRequest):
     prompt = data.prompt
+    provider = data.provider.lower()
 
-    async def generator():
-        try:
-            async for chunk in stream_openai(prompt):
-                yield chunk
-        except Exception:
-            async for chunk in stream_ollama(prompt):
-                yield chunk
-    return StreamingResponse(generator(), media_type="application/json")
+    # Seleccionamos la fuente según lo que elija el usuario
+    if provider == "openai":
+        generator = stream_openai(prompt)
+    elif provider == "ollama":
+        generator = stream_ollama(prompt)
+    else:
+        raise HTTPException(status_code=400, detail="Invalid provider")
+
+    return StreamingResponse(generator, media_type="application/json")

--- a/platino-backend/app/core/config.py
+++ b/platino-backend/app/core/config.py
@@ -5,7 +5,7 @@ class Settings(BaseSettings):
     # Por defecto asumimos que la base de datos se expone en localhost
     # cuando se levanta con `docker compose -f docker-compose.db.yml up -d`.
     database_url: str = "postgresql://postgres:postgres@localhost:5432/platino"
-
+    openai_api_key: str
     class Config:
         env_file = ".env"
 

--- a/platino-backend/app/main.py
+++ b/platino-backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from .api.endpoints import rag, modules
+from .api.endpoints import rag, modules, llm as llm_api
 from .websocket import llm
 from .db.session import engine
 from .db.models import Base
@@ -26,6 +26,7 @@ app.add_middleware(
 
 app.include_router(rag.router, prefix="/api")
 app.include_router(modules.router, prefix="/api")
+app.include_router(llm_api.router, prefix="/api")
 app.include_router(llm.router)
 
 @app.get("/")

--- a/platino-backend/app/websocket/llm.py
+++ b/platino-backend/app/websocket/llm.py
@@ -40,8 +40,10 @@ async def websocket_endpoint(websocket: WebSocket):
 
             try:
                 response = await call_openai(data)
+                print('OpenIA connected')
             except Exception:
                 response = await call_ollama(data)
+                print('Ollama connected')
 
             await websocket.send_text(response)
     except WebSocketDisconnect:

--- a/platino-backend/app/websocket/llm.py
+++ b/platino-backend/app/websocket/llm.py
@@ -1,6 +1,35 @@
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+import os
+import httpx
+from openai import AsyncOpenAI
 
 router = APIRouter()
+
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434/api/generate")
+
+
+async def call_openai(prompt: str) -> str:
+    """Send a prompt to OpenAI ChatGPT."""
+    if not OPENAI_API_KEY:
+        raise ValueError("OPENAI_API_KEY not configured")
+
+    client = AsyncOpenAI(api_key=OPENAI_API_KEY)
+    response = await client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content.strip()
+
+
+async def call_ollama(prompt: str) -> str:
+    """Send a prompt to a local Ollama instance."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(OLLAMA_URL, json={"model": "llama3", "prompt": prompt})
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("response", "")
+
 
 @router.websocket("/ws/chat")
 async def websocket_endpoint(websocket: WebSocket):
@@ -8,8 +37,12 @@ async def websocket_endpoint(websocket: WebSocket):
     try:
         while True:
             data = await websocket.receive_text()
-            # In a real app, call your LLM here
-            response = f"Echo: {data}"
+
+            try:
+                response = await call_openai(data)
+            except Exception:
+                response = await call_ollama(data)
+
             await websocket.send_text(response)
     except WebSocketDisconnect:
         pass

--- a/platino-backend/requirements.txt
+++ b/platino-backend/requirements.txt
@@ -8,3 +8,5 @@ python-dotenv>=1.1.1
 llama-index>=0.10.0
 psycopg2-binary
 PyMuPDF
+openai
+httpx

--- a/platino-frontend/src/pages/dashboard/chat.vue
+++ b/platino-frontend/src/pages/dashboard/chat.vue
@@ -84,7 +84,7 @@ async function uploadPdf(file: File) {
 }
 
 onMounted(async () => {
-  store.connect();
+  // No WebSocket connection needed
 });
 
 // function send() {
@@ -155,15 +155,13 @@ const sendMessageToOllamaStream = async (
   prompt: string,
   onChunk: (text: string) => void
 ) => {
-  const response = await fetch("http://localhost:11434/api/generate", {
+  const response = await fetch("http://localhost:8000/api/chat/stream", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "llama3",
       prompt,
-      stream: true,
     }),
   });
 

--- a/platino-frontend/src/pages/dashboard/chat.vue
+++ b/platino-frontend/src/pages/dashboard/chat.vue
@@ -162,6 +162,7 @@ const sendMessageToOllamaStream = async (
     },
     body: JSON.stringify({
       prompt,
+      provider: "openai",
     }),
   });
 


### PR DESCRIPTION
## Summary
- connect GPT in websocket endpoint
- fallback to local Ollama if API key is missing or invalid
- add `openai` and `httpx` dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686cb599cbb883248b42d16485de8f2f