### PR TITLE
Add document viewer dialog

### DIFF
--- a/platino-backend/app/api/endpoints/rag.py
+++ b/platino-backend/app/api/endpoints/rag.py
@@ -98,6 +98,24 @@ async def list_files(db: Session = Depends(get_db)):
     return {"files": files}
 
 
+@router.get("/files/{doc_id}")
+async def get_file(doc_id: int, db: Session = Depends(get_db)):
+    """Return detailed information for a single document."""
+    doc = db.query(Document).get(doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    return {
+        "id": doc.id,
+        "filename": doc.filename,
+        "filepath": doc.filepath,
+        "thumbnail": doc.thumbnail,
+        "metadata": doc.file_metadata,
+        "chunks": doc.chunks,
+        "topic_id": doc.topic_id,
+    }
+
+
 @router.delete("/files/{doc_id}")
 async def delete_file(doc_id: int, db: Session = Depends(get_db)):
     """Delete a document and its files."""

--- a/platino-frontend/src/pages/dashboard/files.vue
+++ b/platino-frontend/src/pages/dashboard/files.vue
@@ -121,7 +121,7 @@
                   )"
                   :key="doc.id"
                 >
-                  <v-card>
+                  <v-card @click="viewDocument(doc)" class="cursor-pointer">
                     <v-img
                       :src="`http://localhost:8000/${doc.thumbnail}`"
                       height="120"
@@ -145,6 +145,35 @@
       </v-col>
     </v-row>
   </v-container>
+
+  <v-dialog v-model="dialog" max-width="1200">
+    <v-card v-if="selectedDoc">
+      <v-card-title class="d-flex justify-space-between">
+        {{ selectedDoc.filename }}
+        <v-btn icon="mdi-close" @click="dialog = false" />
+      </v-card-title>
+      <v-card-text>
+        <v-row>
+          <v-col cols="12" md="6">
+            <iframe
+              :src="`http://localhost:8000/${selectedDoc.filepath}`"
+              style="width: 100%; height: 75vh"
+            ></iframe>
+          </v-col>
+          <v-col cols="12" md="6" style="max-height: 75vh; overflow-y: auto">
+            <v-list>
+              <v-list-item
+                v-for="(chunk, idx) in selectedDoc.chunks"
+                :key="idx"
+              >
+                <v-list-item-subtitle>{{ chunk }}</v-list-item-subtitle>
+              </v-list-item>
+            </v-list>
+          </v-col>
+        </v-row>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script setup lang="ts">
@@ -158,7 +187,15 @@ interface Doc {
   topic_id: number | null;
 }
 
+interface DocDetail extends Doc {
+  filepath: string;
+  metadata: any;
+  chunks: string[];
+}
+
 const documents = ref<Doc[]>([]);
+const selectedDoc = ref<DocDetail | null>(null);
+const dialog = ref(false);
 interface Topic {
   id: number;
   title: string;
@@ -276,6 +313,13 @@ function removeTopic(module: Module, topic: Topic) {
   axios.delete(`http://localhost:8000/api/topics/${topic.id}`).then(() => {
     module.topics = module.topics.filter((t) => t.id !== topic.id);
     documents.value = documents.value.filter((d) => d.topic_id !== topic.id);
+  });
+}
+
+function viewDocument(doc: Doc) {
+  axios.get(`http://localhost:8000/api/files/${doc.id}`).then((res) => {
+    selectedDoc.value = res.data;
+    dialog.value = true;
   });
 }
 

--- a/platino-frontend/src/pages/dashboard/files.vue
+++ b/platino-frontend/src/pages/dashboard/files.vue
@@ -122,10 +122,20 @@
                   :key="doc.id"
                 >
                   <v-card @click="viewDocument(doc)" class="cursor-pointer">
-                    <v-img
-                      :src="`http://localhost:8000/${doc.thumbnail}`"
-                      height="120"
-                    />
+                    <template v-if="doc.thumbnail">
+                      <v-img
+                        :src="`http://localhost:8000/${doc.thumbnail}`"
+                        height="120"
+                      />
+                    </template>
+                    <template v-else>
+                      <div
+                        class="d-flex align-center justify-center"
+                        style="height: 120px"
+                      >
+                        <v-icon size="64">mdi-file-word</v-icon>
+                      </div>
+                    </template>
                     <v-card-title class="text-wrap">{{
                       doc.filename
                     }}</v-card-title>
@@ -150,25 +160,46 @@
     <v-card v-if="selectedDoc">
       <v-card-title class="d-flex justify-space-between">
         {{ selectedDoc.filename }}
-        <v-btn icon="mdi-close" @click="dialog = false" />
+        <div>
+          <v-btn
+            icon="mdi-download"
+            :href="`http://localhost:8000/${selectedDoc.filepath}`"
+            download
+            class="mr-2"
+          />
+          <v-btn icon="mdi-close" @click="dialog = false" />
+        </div>
       </v-card-title>
       <v-card-text>
         <v-row>
           <v-col cols="12" md="6">
             <iframe
+              v-if="isPdf(selectedDoc.filename)"
               :src="`http://localhost:8000/${selectedDoc.filepath}`"
               style="width: 100%; height: 75vh"
             ></iframe>
+            <div
+              v-else
+              class="d-flex align-center justify-center"
+              style="height: 75vh"
+            >
+              <v-icon size="64">mdi-file-word</v-icon>
+            </div>
           </v-col>
           <v-col cols="12" md="6" style="max-height: 75vh; overflow-y: auto">
-            <v-list>
-              <v-list-item
-                v-for="(chunk, idx) in selectedDoc.chunks"
-                :key="idx"
-              >
-                <v-list-item-subtitle>{{ chunk }}</v-list-item-subtitle>
-              </v-list-item>
-            </v-list>
+            <template v-if="isPdf(selectedDoc.filename)">
+              <v-list>
+                <v-list-item
+                  v-for="(chunk, idx) in selectedDoc.chunks"
+                  :key="idx"
+                >
+                  <v-list-item-subtitle>{{ chunk }}</v-list-item-subtitle>
+                </v-list-item>
+              </v-list>
+            </template>
+            <div v-else class="text-center mt-4">
+              No se puede mostrar previsualización de este archivo
+            </div>
           </v-col>
         </v-row>
       </v-card-text>
@@ -196,6 +227,9 @@ interface DocDetail extends Doc {
 const documents = ref<Doc[]>([]);
 const selectedDoc = ref<DocDetail | null>(null);
 const dialog = ref(false);
+function isPdf(name: string) {
+  return name.toLowerCase().endsWith('.pdf');
+}
 interface Topic {
   id: number;
   title: string;


### PR DESCRIPTION
## Summary
- view file details via new API endpoint
- show document with chunk preview in files view

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-vuetify')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce0dd6f308324ac107f351bb4b894