### PR TITLE
Add persistent embeddings with Chroma and Ollama

### DIFF
--- a/platino-backend/app/api/endpoints/rag.py
+++ b/platino-backend/app/api/endpoints/rag.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import fitz  # PyMuPDF
 from llama_index.readers.file import PyMuPDFReader, PDFReader
 from llama_index.core.node_parser import SimpleNodeParser
+from ...core.rag_engine import insert_nodes
 import tempfile
 import traceback
 from ...db.session import get_db
@@ -16,6 +17,7 @@ router = APIRouter()
 
 UPLOAD_DIR = Path("uploads")
 UPLOAD_DIR.mkdir(exist_ok=True)
+
 
 @router.post("/files")
 async def upload_file(
@@ -41,8 +43,10 @@ async def upload_file(
             metadata["pages"] = doc_pdf.page_count
             page = doc_pdf.load_page(0)
             pix = page.get_pixmap()
-            thumb_path = f"uploads/{file.filename}.png"  # ✅ guarda esto en la base de datos
-            pix.save(UPLOAD_DIR / f"{file.filename}.png")  # ✅ guarda en disco con Path    
+            thumb_path = (
+                f"uploads/{file.filename}.png"  # ✅ guarda esto en la base de datos
+            )
+            pix.save(UPLOAD_DIR / f"{file.filename}.png")  # ✅ guarda en disco con Path
             doc_pdf.close()
 
             pdf_reader = PDFReader()
@@ -50,6 +54,7 @@ async def upload_file(
             parser = SimpleNodeParser.from_defaults()
             nodes = parser.get_nodes_from_documents(documents)
             chunks = [node.text for node in nodes]
+            insert_nodes(nodes)
 
         if topic_id is not None:
             topic = db.query(Topic).get(topic_id)
@@ -81,6 +86,7 @@ async def upload_file(
         print("❌ Error en /files:", e)
         traceback.print_exc()
         raise HTTPException(status_code=400, detail=str(e))
+
 
 @router.get("/files")
 async def list_files(db: Session = Depends(get_db)):
@@ -169,7 +175,9 @@ async def rename_file(doc_id: int, new_name: str, db: Session = Depends(get_db))
 
 
 @router.put("/files/{doc_id}/topic")
-async def set_file_topic(doc_id: int, topic_id: int | None, db: Session = Depends(get_db)):
+async def set_file_topic(
+    doc_id: int, topic_id: int | None, db: Session = Depends(get_db)
+):
     doc = db.query(Document).get(doc_id)
     if not doc:
         raise HTTPException(status_code=404, detail="Document not found")

--- a/platino-backend/app/core/rag_engine.py
+++ b/platino-backend/app/core/rag_engine.py
@@ -2,8 +2,8 @@ from pathlib import Path
 from llama_index.core import (
     VectorStoreIndex,
     StorageContext,
-    ServiceContext,
     load_index_from_storage,
+    Settings,
 )
 from llama_index.vector_stores.chroma import ChromaVectorStore
 from llama_index.embeddings.ollama import OllamaEmbedding
@@ -13,10 +13,11 @@ from llama_index.llms.ollama import Ollama
 PERSIST_DIR = Path("chroma_db")
 COLLECTION_NAME = "documents"
 
-# Initialize embed model and LLM for the service context
+# Initialize embed model and LLM and register them in the global settings
 _embed_model = OllamaEmbedding(model_name="nomic-embed-text")
 _llm = Ollama(model="llama3")
-_service_context = ServiceContext.from_defaults(llm=_llm, embed_model=_embed_model)
+Settings.embed_model = _embed_model
+Settings.llm = _llm
 
 _vector_store = ChromaVectorStore(
     persist_dir=str(PERSIST_DIR), collection_name=COLLECTION_NAME
@@ -25,11 +26,9 @@ _storage_context = StorageContext.from_defaults(vector_store=_vector_store)
 
 # Load an existing index if present, otherwise create a new one
 if PERSIST_DIR.exists():
-    _index = load_index_from_storage(_storage_context, service_context=_service_context)
+    _index = load_index_from_storage(_storage_context)
 else:
-    _index = VectorStoreIndex(
-        [], service_context=_service_context, storage_context=_storage_context
-    )
+    _index = VectorStoreIndex([], storage_context=_storage_context)
     _index.storage_context.persist()
 
 

--- a/platino-backend/app/core/rag_engine.py
+++ b/platino-backend/app/core/rag_engine.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from llama_index.core import (
+    VectorStoreIndex,
+    StorageContext,
+    ServiceContext,
+    load_index_from_storage,
+)
+from llama_index.vector_stores.chroma import ChromaVectorStore
+from llama_index.embeddings.ollama import OllamaEmbedding
+from llama_index.llms.ollama import Ollama
+
+# Directory to persist the Chroma database
+PERSIST_DIR = Path("chroma_db")
+COLLECTION_NAME = "documents"
+
+# Initialize embed model and LLM for the service context
+_embed_model = OllamaEmbedding(model_name="nomic-embed-text")
+_llm = Ollama(model="llama3")
+_service_context = ServiceContext.from_defaults(llm=_llm, embed_model=_embed_model)
+
+_vector_store = ChromaVectorStore(
+    persist_dir=str(PERSIST_DIR), collection_name=COLLECTION_NAME
+)
+_storage_context = StorageContext.from_defaults(vector_store=_vector_store)
+
+# Load an existing index if present, otherwise create a new one
+if PERSIST_DIR.exists():
+    _index = load_index_from_storage(_storage_context, service_context=_service_context)
+else:
+    _index = VectorStoreIndex(
+        [], service_context=_service_context, storage_context=_storage_context
+    )
+    _index.storage_context.persist()
+
+
+def insert_nodes(nodes):
+    """Insert nodes into the index and persist the vector store."""
+    _index.insert_nodes(nodes)
+    _index.storage_context.persist()
+
+
+def query(text: str):
+    """Query the index and return the LLM response."""
+    query_engine = _index.as_query_engine()
+    return query_engine.query(text)

--- a/platino-backend/app/websocket/llm.py
+++ b/platino-backend/app/websocket/llm.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from ..core.rag_engine import query
 
 router = APIRouter()
+
 
 @router.websocket("/ws/chat")
 async def websocket_endpoint(websocket: WebSocket):
@@ -8,8 +10,7 @@ async def websocket_endpoint(websocket: WebSocket):
     try:
         while True:
             data = await websocket.receive_text()
-            # In a real app, call your LLM here
-            response = f"Echo: {data}"
-            await websocket.send_text(response)
+            response = query(data)
+            await websocket.send_text(str(response))
     except WebSocketDisconnect:
         pass

--- a/platino-backend/requirements.txt
+++ b/platino-backend/requirements.txt
@@ -8,3 +8,6 @@ python-dotenv>=1.1.1
 llama-index>=0.10.0
 psycopg2-binary
 PyMuPDF
+chromadb
+llama-index-llms-ollama
+llama-index-embeddings-ollama


### PR DESCRIPTION
## Summary
- store embeddings from uploaded documents in a persistent ChromaDB instance
- provide simple RAG engine using LlamaIndex and Ollama
- update websocket to answer with context-aware responses
- include new dependencies for ChromaDB and Ollama extensions

## Testing
- `black platino-backend/app/core/rag_engine.py platino-backend/app/api/endpoints/rag.py platino-backend/app/websocket/llm.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d2c9dd9c88324bf856cfa8f583700