### PR TITLE
Add Vuetify theme toggle

### DIFF
--- a/platino-frontend/src/pages/dashboard/index.vue
+++ b/platino-frontend/src/pages/dashboard/index.vue
@@ -9,6 +9,10 @@
       <v-icon>mdi-magnify</v-icon>
     </v-btn>
 
+    <v-btn icon @click="toggleTheme">
+      <v-icon>mdi-theme-light-dark</v-icon>
+    </v-btn>
+
     <v-btn icon>
       <v-icon>mdi-dots-vertical</v-icon>
     </v-btn>
@@ -34,6 +38,7 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
+import { useTheme } from "vuetify";
 
 const drawerItems = ref([
   {
@@ -53,4 +58,9 @@ const drawerItems = ref([
   },
 ]);
 const currentDrawer = ref(false);
+const theme = useTheme();
+function toggleTheme() {
+  theme.global.name.value =
+    theme.global.name.value === "dark" ? "light" : "dark";
+}
 </script>


### PR DESCRIPTION
## Summary
- add a new icon button in the dashboard app bar to toggle Vuetify theme
- implement theme switch logic with `useTheme`

## Testing
- `npm --prefix platino-frontend run lint` *(fails: Cannot find package 'eslint-config-vuetify')*

------
https://chatgpt.com/codex/tasks/task_e_687771ae84548324a3638a3e14917e1e