### PR TITLE
Add axios error popup

### DIFF
--- a/platino-frontend/src/App.vue
+++ b/platino-frontend/src/App.vue
@@ -1,10 +1,13 @@
 <template>
   <v-layout class="rounded rounded-md border fill-height">
     <RouterView />
+    <NotificationSnackbar />
   </v-layout>
 </template>
 
-<script lang="ts" setup></script>
+<script lang="ts" setup>
+import NotificationSnackbar from './components/NotificationSnackbar.vue'
+</script>
 <style lang="scss">
 #app {
   height: 100vh;

--- a/platino-frontend/src/components.d.ts
+++ b/platino-frontend/src/components.d.ts
@@ -10,6 +10,7 @@ declare module 'vue' {
   export interface GlobalComponents {
     AppFooter: typeof import('./components/AppFooter.vue')['default']
     HelloWorld: typeof import('./components/HelloWorld.vue')['default']
+    NotificationSnackbar: typeof import('./components/NotificationSnackbar.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     Spinner: typeof import('./components/ui/spinner.vue')['default']

--- a/platino-frontend/src/components/NotificationSnackbar.vue
+++ b/platino-frontend/src/components/NotificationSnackbar.vue
@@ -1,0 +1,10 @@
+<template>
+  <v-snackbar v-model="store.show" :color="store.color" multi-line>
+    {{ store.message }}
+  </v-snackbar>
+</template>
+
+<script setup lang="ts">
+import { useNotificationStore } from '@/stores/notifications'
+const store = useNotificationStore()
+</script>

--- a/platino-frontend/src/main.ts
+++ b/platino-frontend/src/main.ts
@@ -15,10 +15,12 @@ import { createApp } from 'vue'
 
 // Styles
 import 'unfonts.css'
-import axiosInstance from "./plugins/axios";
+import axiosInstance, { setupAxiosInterceptors } from "./plugins/axios";
 const app = createApp(App)
 
 registerPlugins(app)
+
+setupAxiosInterceptors()
 
 app.config.globalProperties.$axios = axiosInstance;
 

--- a/platino-frontend/src/plugins/axios.ts
+++ b/platino-frontend/src/plugins/axios.ts
@@ -1,8 +1,21 @@
 import axios from "axios";
+import { useNotificationStore } from "@/stores/notifications";
 
 const axiosInstance = axios.create({
   baseURL: "https://mi.api.com/",
   // Aquí puedes añadir más configuraciones como headers por defecto
 });
+
+export function setupAxiosInterceptors() {
+  axiosInstance.interceptors.response.use(
+    (response) => response,
+    (error) => {
+      const store = useNotificationStore();
+      const msg = error.response?.data?.detail || error.message;
+      store.notify(msg, "error");
+      return Promise.reject(error);
+    }
+  );
+}
 
 export default axiosInstance;

--- a/platino-frontend/src/stores/notifications.ts
+++ b/platino-frontend/src/stores/notifications.ts
@@ -1,0 +1,16 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useNotificationStore = defineStore('notification', () => {
+  const show = ref(false)
+  const message = ref('')
+  const color = ref<'success' | 'info' | 'error' | 'warning'>('error')
+
+  function notify(msg: string, col: 'success' | 'info' | 'error' | 'warning' = 'error') {
+    message.value = msg
+    color.value = col
+    show.value = true
+  }
+
+  return { show, message, color, notify }
+})


### PR DESCRIPTION
## Summary
- show a Vuetify snackbar for request errors
- hook axios interceptors into the app

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-vuetify' due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6883a4ec2654832493aaac7fe7050cb8