### PR TITLE
Organize docker compose stack and document local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+# PLATINO
+
+Este proyecto incluye un backend FastAPI, un frontend Vite/Vue y servicios auxiliares como Ollama, PostgreSQL y Qdrant.
+
+## Levantar todo con Docker Compose
+
+Requiere [Docker](https://docs.docker.com/get-docker/) y [Docker Compose](https://docs.docker.com/compose/).
+
+```bash
+docker compose up -d --build
+```
+
+Esto inicia los servicios:
+
+- **ollama**: servidor de modelos LLM
+- **db**: base de datos PostgreSQL
+- **qdrant**: base de datos vectorial
+- **backend**: API FastAPI
+- **frontend**: interfaz web Vite
+
+El frontend queda disponible en `http://localhost:5173` (puerto configurable con `FRONTEND_PORT`).
+
+Para detener todos los servicios:
+
+```bash
+docker compose down
+```
+
+## Desarrollo manual en local
+
+Para desarrollar sin levantar todo con Docker, solo se usa un contenedor para la base de datos SQL. Los demás servicios se ejecutan directamente en el host.
+
+1. **Base de datos**
+
+   ```bash
+   docker compose -f docker-compose.db.yml up -d
+   ```
+
+2. **Qdrant**
+
+   Instala Qdrant localmente siguiendo la [documentación oficial](https://qdrant.tech/documentation/).
+   Luego inicia el servicio:
+
+   ```bash
+   qdrant
+   ```
+
+3. **Ollama**
+
+   Instala [Ollama](https://ollama.com/download) y ejecuta el servidor:
+
+   ```bash
+   ollama serve
+   ```
+
+4. **Backend**
+
+   ```bash
+   cd platino-backend
+   pip install -r requirements.txt
+   export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/platino
+   export QDRANT_URL=http://localhost:6333
+   uvicorn app.main:app --reload
+   ```
+
+5. **Frontend**
+
+   ```bash
+   cd platino-frontend
+   cp .env.example .env
+   npm install
+   npm run dev
+   ```
+
+   El frontend se conecta al backend mediante la variable `VITE_API_URL` y a Ollama mediante `VITE_OLLAMA_URL`, ambas definidas en `.env`.
+
+Con estos pasos tendrás todos los servicios funcionando en tu entorno local.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: ollama/ollama
     container_name: ollama-platino
     ports:
-      - "${OLLAMA_PORT}:11434"
+      - "${OLLAMA_PORT:-11434}:11434"
     volumes:
       - ollama_models:/root/.ollama
     restart: unless-stopped
@@ -16,20 +16,20 @@ services:
     container_name: platino-db
     restart: unless-stopped
     environment:
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-platino}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
-      - "${DB_PORT}:5432"
+      - "${DB_PORT:-5432}:5432"
 
   qdrant:
     image: qdrant/qdrant
     container_name: platino-qdrant
     restart: unless-stopped
     ports:
-      - "${QDRANT_PORT}:6333"
+      - "${QDRANT_PORT:-6333}:6333"
     volumes:
       - qdrant_data:/qdrant/storage
 
@@ -37,31 +37,35 @@ services:
     build:
       context: ./platino-backend
     container_name: platino-backend
-    command: uvicorn app.main:app --host 0.0.0.0 --port ${BACKEND_PORT} --reload
+    command: uvicorn app.main:app --host 0.0.0.0 --port ${BACKEND_PORT:-8000} --reload
     volumes:
       - ./platino-backend:/app
     ports:
-      - "${BACKEND_PORT}:8000"
+      - "${BACKEND_PORT:-8000}:8000"
     environment:
-      - DATABASE_URL=${DATABASE_URL}
-      - QDRANT_URL=${QDRANT_URL}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-platino}
+      - QDRANT_URL=http://qdrant:6333
     depends_on:
       - db
       - ollama
       - qdrant
 
-  # frontend:
-  #   build:
-  #     context: ./platino-frontend
-  #   container_name: platino-frontend
-  #   command: npm run dev -- --host
-  #   volumes:
-  #     - ./platino-frontend:/app
-  #     - /app/node_modules
-  #   ports:
-  #     - "${FRONTEND_PORT}:5173"
-  #   depends_on:
-  #     - backend
+  frontend:
+    build:
+      context: ./platino-frontend
+    container_name: platino-frontend
+    command: npm run dev -- --host
+    volumes:
+      - ./platino-frontend:/app
+      - /app/node_modules
+    ports:
+      - "${FRONTEND_PORT:-5173}:5173"
+    environment:
+      - VITE_API_URL=http://backend:${BACKEND_PORT:-8000}
+      - VITE_OLLAMA_URL=http://ollama:11434
+    depends_on:
+      - backend
+      - ollama
 
 volumes:
   ollama_models:

--- a/platino-frontend/.env.example
+++ b/platino-frontend/.env.example
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:8000
+VITE_OLLAMA_URL=http://localhost:11434

--- a/platino-frontend/src/pages/dashboard/chat.vue
+++ b/platino-frontend/src/pages/dashboard/chat.vue
@@ -3,7 +3,7 @@
     class="container pa-3 d-flex flex-column justify-content-between fill-height"
   >
     <div class="messages-container pt-4">
-      <div v-if="messages.length" class="messages-list">
+      <div v-if="messages.length > 0" class="messages-list">
         <div
           v-for="(msg, index) in messages"
           :key="index"
@@ -23,205 +23,207 @@
       <div v-if="error" class="text-error">{{ error }}</div>
     </div>
     <div class="mt-3 input-container">
-      <spinner v-if="isLoading"></spinner>
+      <spinner v-if="isLoading" />
       <!-- Input de PDF oculto -->
       <input
         ref="fileInput"
-        type="file"
         accept="application/pdf"
         class="d-none"
-        @change="handleFileChange"
         :disabled="isLoading"
-      />
+        type="file"
+        @change="handleFileChange"
+      >
 
       <!-- Input de texto -->
       <v-text-field
         v-model="input"
-        label="Escribe tu mensaje"
         append-icon="mdi-send"
+        label="Escribe tu mensaje"
         @click:append="send"
-        @keyup.enter="send"
         @dragover.prevent
         @drop.prevent="onDrop"
+        @keyup.enter="send"
       />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from "vue";
-import { useOllamaStore } from "@/stores/ollama";
-import axios from "@/plugins/axios";
+  import { computed, onMounted, ref } from 'vue'
+  import spinner from '@/components/ui/spinner.vue'
+  import axios from '@/plugins/axios'
 
-import spinner from "@/components/ui/spinner.vue";
+  import { useOllamaStore } from '@/stores/ollama'
 
-const store = useOllamaStore();
-const input = ref("");
-const messages = computed(() => store.messages);
-const fileInput = ref<HTMLInputElement | null>(null);
-const isLoading = ref(false);
-const error = ref("");
+  const store = useOllamaStore()
+  const input = ref('')
+  const messages = computed(() => store.messages)
+  const fileInput = ref<HTMLInputElement | null>(null)
+  const isLoading = ref(false)
+  const error = ref('')
 
-function onDrop(e: DragEvent) {
-  const files = e.dataTransfer?.files;
-  if (files && files.length > 0) {
-    uploadPdf(files[0]);
-  }
-}
-
-function handleFileChange(e: Event) {
-  const target = e.target as HTMLInputElement;
-  const files = target.files;
-  if (files && files.length > 0) {
-    uploadPdf(files[0]);
-  }
-  if (target) target.value = "";
-}
-
-async function uploadPdf(file: File) {
-  const formData = new FormData();
-  formData.append("file", file);
-  try {
-    const { data } = await axios.post(
-      "api/files_2",
-      formData
-    );
-    if (data.chunks) {
-      data.chunks.forEach((chunk: string) => {
-        store.addMessage({ from: "ai", text: chunk });
-      });
+  function onDrop (e: DragEvent) {
+    const files = e.dataTransfer?.files
+    if (files && files.length > 0) {
+      uploadPdf(files[0])
     }
-  } catch (err) {
-    console.error("Error al dividir PDF:", err);
   }
-}
 
-onMounted(async () => {
-  store.connect();
-});
-
-// function send() {
-//   if (!input.value) return;
-//   store.sendMessage(input.value);
-//   input.value = "";
-// }
-
-const sendMesageToOllama = async (message: string) => {
-  try {
-    const response = await axios.post("http://localhost:11434/api/generate", {
-      model: "llama3",
-      prompt: message,
-      stream: true,
-    });
-    return response.data;
-  } catch (error) {
-    console.error("Error al enviar el mensaje a Ollama:", error);
-    return null;
+  function handleFileChange (e: Event) {
+    const target = e.target as HTMLInputElement
+    const files = target.files
+    if (files && files.length > 0) {
+      uploadPdf(files[0])
+    }
+    if (target) target.value = ''
   }
-};
-// function send() {
-//   if (!input.value) return;
-//   let text = input.value;
-//   input.value = "";
-//   store.addMessage({
-//     from: "user",
-//     text: text,
-//   });
-//   sendMesageToOllama(text).then((response) => {
-//     if (response) {
-//       store.addMessage({
-//         from: "ai",
-//         text: response.response,
-//       });
-//     }
-//   });
-// }
-function send() {
-  if (!input.value) return;
 
-  const text = input.value;
-  input.value = "";
-
-  // Agregar mensaje del usuario
-  store.addMessage({
-    from: "user",
-    text,
-  });
-
-  // Inicializar mensaje del asistente
-  let aiResponse = "";
-  store.addMessage({
-    from: "ai",
-    text: aiResponse,
-  });
-
-  // Referencia al mensaje recién agregado para ir actualizándolo
-  const aiIndex = store.messages.length - 1;
-
-  error.value = "";
-  sendMessageToOllamaStream(text, (chunk) => {
-    aiResponse += chunk;
-    store.messages[aiIndex].text = aiResponse;
-  }).catch(() => {
-    store.messages[aiIndex].text = "";
-  });
-}
-
-const sendMessageToOllamaStream = async (
-  prompt: string,
-  onChunk: (text: string) => void
-) => {
-  isLoading.value = true;
-  try {
-    const response = await fetch("http://localhost:11434/api/generate", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: "llama3",
-        prompt,
-        stream: true,
-      }),
-    });
-
-    const reader = response.body?.getReader();
-    const decoder = new TextDecoder("utf-8");
-
-    let fullText = "";
-
-    if (!reader) throw new Error("sin lector");
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      const chunk = decoder.decode(value, { stream: true });
-
-      // Ollama envía múltiples objetos JSON por línea
-      const lines = chunk.split("\n").filter(Boolean);
-
-      for (const line of lines) {
-        try {
-          const json = JSON.parse(line);
-          if (json.response) {
-            fullText += json.response;
-            onChunk(json.response); // Emite fragmento
-          }
-        } catch (err) {
-          console.error("Error al parsear línea:", line, err);
+  async function uploadPdf (file: File) {
+    const formData = new FormData()
+    formData.append('file', file)
+    try {
+      const { data } = await axios.post(
+        'api/files_2',
+        formData,
+      )
+      if (data.chunks) {
+        for (const chunk of data.chunks as string[]) {
+          store.addMessage({ from: 'ai', text: chunk })
         }
       }
+    } catch (error_) {
+      console.error('Error al dividir PDF:', error_)
     }
-
-    return fullText;
-  } catch (err) {
-    error.value = "Error al comunicarse con la IA";
-    throw err;
-  } finally {
-    isLoading.value = false;
   }
-};
+
+  onMounted(async () => {
+    store.connect()
+  })
+
+  // function send() {
+  //   if (!input.value) return;
+  //   store.sendMessage(input.value);
+  //   input.value = "";
+  // }
+
+  const OLLAMA_URL = import.meta.env.VITE_OLLAMA_URL || 'http://localhost:11434'
+
+  const _sendMesageToOllama = async (message: string) => {
+    try {
+      const response = await axios.post(`${OLLAMA_URL}/api/generate`, {
+        model: 'llama3',
+        prompt: message,
+        stream: true,
+      })
+      return response.data
+    } catch (error) {
+      console.error('Error al enviar el mensaje a Ollama:', error)
+      return null
+    }
+  }
+  // function send() {
+  //   if (!input.value) return;
+  //   let text = input.value;
+  //   input.value = "";
+  //   store.addMessage({
+  //     from: "user",
+  //     text: text,
+  //   });
+  //   sendMesageToOllama(text).then((response) => {
+  //     if (response) {
+  //       store.addMessage({
+  //         from: "ai",
+  //         text: response.response,
+  //       });
+  //     }
+  //   });
+  // }
+  function send () {
+    if (!input.value) return
+
+    const text = input.value
+    input.value = ''
+
+    // Agregar mensaje del usuario
+    store.addMessage({
+      from: 'user',
+      text,
+    })
+
+    // Inicializar mensaje del asistente
+    let aiResponse = ''
+    store.addMessage({
+      from: 'ai',
+      text: aiResponse,
+    })
+
+    // Referencia al mensaje recién agregado para ir actualizándolo
+    const aiIndex = store.messages.length - 1
+
+    error.value = ''
+    sendMessageToOllamaStream(text, chunk => {
+      aiResponse += chunk
+      store.messages[aiIndex].text = aiResponse
+    }).catch(() => {
+      store.messages[aiIndex].text = ''
+    })
+  }
+
+  const sendMessageToOllamaStream = async (
+    prompt: string,
+    onChunk: (text: string) => void,
+  ) => {
+    isLoading.value = true
+    try {
+      const response = await fetch(`${OLLAMA_URL}/api/generate`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'llama3',
+          prompt,
+          stream: true,
+        }),
+      })
+
+      const reader = response.body?.getReader()
+      const decoder = new TextDecoder('utf8')
+
+      let fullText = ''
+
+      if (!reader) throw new Error('sin lector')
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        const chunk = decoder.decode(value, { stream: true })
+
+        // Ollama envía múltiples objetos JSON por línea
+        const lines = chunk.split('\n').filter(Boolean)
+
+        for (const line of lines) {
+          try {
+            const json = JSON.parse(line)
+            if (json.response) {
+              fullText += json.response
+              onChunk(json.response) // Emite fragmento
+            }
+          } catch (error_) {
+            console.error('Error al parsear línea:', line, error_)
+          }
+        }
+      }
+
+      return fullText
+    } catch (error_) {
+      error.value = 'Error al comunicarse con la IA'
+      throw error_
+    } finally {
+      isLoading.value = false
+    }
+  }
 </script>
 <style lang="scss" scoped>
 .container {


### PR DESCRIPTION
## Summary
- expand docker-compose to run ollama, backend, frontend, postgres and qdrant together
- support configurable Ollama URL in frontend and provide sample environment file
- document docker-compose and manual development setup

## Testing
- `npx eslint src/pages/dashboard/chat.vue` (warning only, no errors)
- `npm run type-check`
- `docker compose config` *(fails: command not found, docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688f1c2217ec8324a91747c0d29c998e